### PR TITLE
Scraper enhancements

### DIFF
--- a/Alabama/Autauga.md
+++ b/Alabama/Autauga.md
@@ -1,5 +1,7 @@
 ## Covid tips for Autauga, Alabama
+---
 
-Bing Search for 'site:gov Autauga County Alabama covid vaccine access'
-https://www.alabamapublichealth.gov/news/2021/01/26a.html
-Retrieved on Friday, February 12, 2021 at 5:35AM (UTC)
+### 'Bing' search for **'site:gov Autauga County Alabama covid vaccine access'**
+
+**Link:** [https://www.alabamapublichealth.gov/news/2021/01/26a.html](https://www.alabamapublichealth.gov/news/2021/01/26a.html)
+*(Retrieved on Friday, February 12, 2021 at 5:35AM (UTC))*

--- a/Alabama/Coffee.md
+++ b/Alabama/Coffee.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Coffee, Alabama
+
+
+<br>
+
+---
+### 'Bing' Search for **'site:gov Coffee County Alabama covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:05PM (UTC)*
+
+**Link: [https://www.alabamapublichealth.gov/news/2021/02/01.html](https://www.alabamapublichealth.gov/news/2021/02/01.html)**

--- a/Illinois/Boone.md
+++ b/Illinois/Boone.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Boone, Illinois
+
+
+<br>
+
+---
+### 'Bing' Search for **'site:gov Boone County Illinois covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:17PM (UTC)*
+
+**Link: [https://coronavirus.illinois.gov/s/vaccination-location](https://coronavirus.illinois.gov/s/vaccination-location)**

--- a/Illinois/Christian.md
+++ b/Illinois/Christian.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Christian, Illinois
+
+
+<br>
+
+---
+### 'Yahoo' Search for **'site:gov Christian County Illinois covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:17PM (UTC)*
+
+**Link: [http://dph.illinois.gov/covid19](http://dph.illinois.gov/covid19)**

--- a/Indiana/Grant.md
+++ b/Indiana/Grant.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Grant, Indiana
+
+
+<br>
+
+---
+### 'Ask' Search for **'Grant County Indiana covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:06PM (UTC)*
+
+**Link: [https://www.ask.com/culture/ask-answers-covid19-vaccine?ad=dirN&qo=serpIndex&o=740004](https://www.ask.com/culture/ask-answers-covid19-vaccine?ad=dirN&qo=serpIndex&o=740004)**

--- a/Indiana/Jefferson.md
+++ b/Indiana/Jefferson.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Jefferson, Indiana
+
+
+<br>
+
+---
+### 'Ask' Search for **'site:gov Jefferson County Indiana covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:04PM (UTC)*
+
+**Link: [https://www.ask.com/article/oakland-coliseum-and-cal-state-la-selected-as-first-federal-covid-19-vaccination-sites?ad=dirN&qo=serpIndex&o=740004](https://www.ask.com/article/oakland-coliseum-and-cal-state-la-selected-as-first-federal-covid-19-vaccination-sites?ad=dirN&qo=serpIndex&o=740004)**

--- a/Indiana/Noble.md
+++ b/Indiana/Noble.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Noble, Indiana
+
+
+<br>
+
+---
+### 'Bing' Search for **'site:gov Noble County Indiana covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:06PM (UTC)*
+
+**Link: [http://coronavirus.in.gov/vaccine/](http://coronavirus.in.gov/vaccine/)**

--- a/Indiana/Parke.md
+++ b/Indiana/Parke.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Parke, Indiana
+
+
+<br>
+
+---
+### 'Bing' Search for **'site:gov Parke County Indiana covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:04PM (UTC)*
+
+**Link: [http://coronavirus.in.gov/](http://coronavirus.in.gov/)**

--- a/Iowa/Franklin.md
+++ b/Iowa/Franklin.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Franklin, Iowa
+
+
+<br>
+
+---
+### 'Ask' Search for **'site:gov Franklin County Iowa covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:17PM (UTC)*
+
+**Link: [https://www.linncounty-ia.gov/DocumentCenter/View/15477/CVS-Covid-Vac](https://www.linncounty-ia.gov/DocumentCenter/View/15477/CVS-Covid-Vac)**

--- a/Iowa/Pocahontas.md
+++ b/Iowa/Pocahontas.md
@@ -1,1 +1,11 @@
-No tips submitted for this location yet.
+## Covid tips for Pocahontas, Iowa
+
+
+<br>
+
+---
+### 'Bing' Search for **'site:gov Pocahontas County Iowa covid vaccine access'**
+
+*Retrieved Friday, February 12, 2021 at 11:05PM (UTC)*
+
+**Link: [https://pocahontascounty.iowa.gov/public-health/](https://pocahontascounty.iowa.gov/public-health/)**

--- a/scrape.py
+++ b/scrape.py
@@ -70,7 +70,7 @@ def main():
         engine_times = dict()
         r = csv.reader(f, delimiter=',')
         for row in r:
-            county, state = row[0], row[1]
+            county, state = replace_underscores(row[0]), replace_underscores(row[1])
             prush("{}, {}...".format(county, state))
 
             time_since_last_use = 0
@@ -108,7 +108,7 @@ def main():
 
             title = fmt_title(engine_name, subject)
             access_time = fmt_access_time()
-
+                
             markdown = ""
             with open(state + "/" + county + ".md", "r") as county_file:
                 markdown = county_file.read()
@@ -131,6 +131,10 @@ def select_best_search_result(search_results):
     # currently implemented to just return the top result, this could be
     # extended in any number of ways.
     return search_results[0]
+
+
+def replace_underscores(s):
+    return s.replace("_", " ")
 
 
 def fmt_title(engine_name, subject):

--- a/scrape.py
+++ b/scrape.py
@@ -150,7 +150,7 @@ def fmt_access_time():
 
 
 def fmt_page_heading(county, state):
-    return "## Covid tips for {}, {}\n---".format(county, state)
+    return "## Covid tips for {}, {}\n".format(county, state)
 
 
 def fmt_uri(uri):
@@ -158,7 +158,7 @@ def fmt_uri(uri):
 
 
 def fmt_entry(title, uri, access_time):
-    return "\n\n{}\n\n{}\n\n{}".format(title, access_time, uri)
+    return "---{}\n\n{}\n\n{}".format(title, access_time, uri)
 
 
 def prush(*args):

--- a/scrape.py
+++ b/scrape.py
@@ -118,7 +118,7 @@ def main():
                 continue
 
             best_result = select_best_search_result(search_results)
-            
+
             uri = fmt_uri(best_result)
 
             if len(markdown.strip()) == 0 or NO_TIPS_PLACEHOLDER.lower() in markdown.lower():
@@ -145,7 +145,7 @@ def fmt_title(engine_name, subject):
 
 
 def fmt_access_time():
-    return "Retrieved on {}".format(
+    return "*(Retrieved on {})*".format(
         datetime.utcnow().strftime("%A, %B %-d, %Y at %-I:%M%p (UTC)"))
 
 
@@ -154,7 +154,7 @@ def fmt_page_heading(county, state):
 
 
 def fmt_uri(uri):
-    return "**Link: [uri](uri)**"
+    return "**Link: [{}]({})**".format(uri, uri)
 
 
 def fmt_entry(title, uri, access_time):

--- a/scrape.py
+++ b/scrape.py
@@ -139,7 +139,7 @@ def replace_underscores(s):
 
 
 def fmt_title(engine_name, subject):
-    return "{} Search for '{}'".format(engine_name, subject)
+    return "### '{}' Search for **'{}'**".format(engine_name, subject)
 
 
 def fmt_access_time():

--- a/scrape.py
+++ b/scrape.py
@@ -70,7 +70,8 @@ def main():
         engine_times = dict()
         r = csv.reader(f, delimiter=',')
         for row in r:
-            county, state = replace_underscores(row[0]), replace_underscores(row[1])
+            county, state = replace_underscores(
+                row[0]), replace_underscores(row[1])
             prush("{}, {}...".format(county, state))
 
             time_since_last_use = 0
@@ -108,7 +109,7 @@ def main():
 
             title = fmt_title(engine_name, subject)
             access_time = fmt_access_time()
-                
+
             markdown = ""
             with open(state + "/" + county + ".md", "r") as county_file:
                 markdown = county_file.read()
@@ -147,7 +148,7 @@ def fmt_access_time():
 
 
 def fmt_page_heading(county, state):
-    return "## Covid tips for {}, {}".format(county, state)
+    return "## Covid tips for {}, {}\n---".format(county, state)
 
 
 def fmt_entry(title, uri, access_time):

--- a/scrape.py
+++ b/scrape.py
@@ -161,7 +161,7 @@ def get_prioritized_county_list():
     # Naive quartile implementation is safe so long as we have many counties to
     # work from.
     county_info_list = sorted(county_info_list, key=lambda x: x.density)
-    quartile_size = len(county_info_list) / 4
+    quartile_size = len(county_info_list) // 4
     q1 = county_info_list[quartile_size*0:quartile_size*1]
     q2 = county_info_list[quartile_size*1:quartile_size*2]
     q3 = county_info_list[quartile_size*2:quartile_size*3]

--- a/scrape.py
+++ b/scrape.py
@@ -144,6 +144,15 @@ class CountyInfo:
 
 
 def get_prioritized_county_list():
+    """the scraper prioritizes its work such that counties with less recorded
+    information are addressed before counties with more information. This is
+    accomplished by dividing the counties into quartiles based on an estimate
+    of the amount of information collected for each county (the first quartile
+    being counties with the least recorded information). Within each
+    quartile, the counties are randomized.  This allows the scraper to cast a
+    broader net each time it runs. This helps ensure that each county still has
+    a good chance at being scraped even if the scraper is only able to run for
+    short periods of time."""
     county_info_list = []
     with open('county_list.csv', newline='', encoding='iso8859_15') as f:
         r = csv.reader(f, delimiter=',')

--- a/scrape.py
+++ b/scrape.py
@@ -136,10 +136,28 @@ def main():
                 county_file.write(markdown)
 
 
+class CountyInfo:
+    def __init__(self, county, state, density):
+        self.county = county
+        self.state = state
+        self.density = density
+
+
 def select_best_search_result(search_results):
-    # currently implemented to just return the top result, this could be
-    # extended in any number of ways.
-    return search_results[0]
+    county_info_list = []
+    with open('county_list.csv', newline='') as f:
+        r = csv.reader(f, delimiter=',')
+        for row in r:
+            county, state = row[0], row[1]
+            with open(state + "/" + county + ".md", "r") as county_file:
+                density = calculate_information_density(county_file.read())
+                county_info_list.append(CountyInfo(county, state, density))
+
+
+def calculate_information_density(text):
+    """estimate information density based on the count of non-whitespace
+    characters in the text"""
+    return len(["" if c in ['\n', '\r', '\t', ' '] else c for c in text])
 
 
 def replace_underscores(s):

--- a/scrape.py
+++ b/scrape.py
@@ -157,7 +157,6 @@ def get_prioritized_county_list():
     with open('county_list.csv', newline='', encoding='iso8859_15') as f:
         r = csv.reader(f, delimiter=',')
         for row in r:
-            print(row)
             county, state = row[0], row[1]
             file_name = state + "/" + county + ".md"
             try:

--- a/scrape.py
+++ b/scrape.py
@@ -158,7 +158,7 @@ def fmt_uri(uri):
 
 
 def fmt_entry(title, uri, access_time):
-    return "\n\n{}\n{}\n{}".format(title, uri, access_time)
+    return "\n\n{}\n\n{}\n\n{}".format(title, access_time, uri)
 
 
 def prush(*args):

--- a/scrape.py
+++ b/scrape.py
@@ -66,74 +66,69 @@ search_engines = [
 
 
 def main():
-    with open('county_list.csv', newline='') as f:
-        engine_times = dict()
-        r = csv.reader(f, delimiter=',')
-        for row in r:
-            # use these instances to access files (may contain underscores)
-            county, state = row[0], row[1]
+    engine_times = dict()
+    for (county, state) in get_prioritized_county_list():
+        # use these values for search queries and formatted output
+        county_clean, state_clean = replace_underscores(
+            county), replace_underscores(state)
 
-            # use these values for search queries and formatted output
-            county_clean, state_clean = replace_underscores(
-                county), replace_underscores(state)
+        prush("{}, {}...".format(county_clean, state_clean))
 
-            prush("{}, {}...".format(county_clean, state_clean))
+        time_since_last_use = 0
+        engine_name = ""
+        while True:
+            # This does basically constitute a busy loop if all engines are
+            # in a cooldown period, but since this is single threaded, I'm
+            # not too concerned.
+            engine = random.choice(search_engines)()
+            engine_name = engine.__class__.__name__
+            if not engine_name in engine_times:
+                break
+            time_since_last_use = (
+                datetime.now() - engine_times[engine_name]).total_seconds()
+            if time_since_last_use >= ENGINE_MIN_COOLDOWN_SECS:
+                break
 
-            time_since_last_use = 0
-            engine_name = ""
-            while True:
-                # This does basically constitute a busy loop if all engines are
-                # in a cooldown period, but since this is single threaded, I'm
-                # not too concerned.
-                engine = random.choice(search_engines)()
-                engine_name = engine.__class__.__name__
-                if not engine_name in engine_times:
-                    break
-                time_since_last_use = (
-                    datetime.now() - engine_times[engine_name]).total_seconds()
-                if time_since_last_use >= ENGINE_MIN_COOLDOWN_SECS:
-                    break
+        engine.set_headers({'User-Agent': get_random_user_agent()})
+        subject = PREFERRED_SEARCH_TEMPLATE.format(
+            county_clean, state_clean)
+        search_results = engine.search(subject, pages=SEARCH_PAGES).links()
+        engine_times[engine_name] = datetime.now()
 
-            engine.set_headers({'User-Agent': get_random_user_agent()})
-            subject = PREFERRED_SEARCH_TEMPLATE.format(
+        if len(search_results) == 0:
+            subject = ALTERNATE_SEARCH_TEMPLATE.format(
                 county_clean, state_clean)
-            search_results = engine.search(subject, pages=SEARCH_PAGES).links()
-            engine_times[engine_name] = datetime.now()
 
-            if len(search_results) == 0:
-                subject = ALTERNATE_SEARCH_TEMPLATE.format(
-                    county_clean, state_clean)
+            # Random-uniform wait period between successive calls to same
+            # engine adds some delay and jitter to the calls, making it
+            # just slightly harder to get rate-limited.
+            time.sleep(random.uniform(
+                ALTERNATE_SEARCH_MIN_WAIT_SECS, ALTERNATE_SEARCH_MAX_WAIT_SECS))
 
-                # Random-uniform wait period between successive calls to same
-                # engine adds some delay and jitter to the calls, making it
-                # just slightly harder to get rate-limited.
-                time.sleep(random.uniform(
-                    ALTERNATE_SEARCH_MIN_WAIT_SECS, ALTERNATE_SEARCH_MAX_WAIT_SECS))
+            search_results = engine.search(
+                subject, pages=SEARCH_PAGES).links()
 
-                search_results = engine.search(
-                    subject, pages=SEARCH_PAGES).links()
+        title = fmt_title(engine_name, subject)
+        access_time = fmt_access_time()
 
-            title = fmt_title(engine_name, subject)
-            access_time = fmt_access_time()
+        markdown = ""
+        with open(state + "/" + county + ".md", "r") as county_file:
+            markdown = county_file.read()
 
-            markdown = ""
-            with open(state + "/" + county + ".md", "r") as county_file:
-                markdown = county_file.read()
+        if len(search_results) == 0 or search_results[0] in markdown:
+            continue
 
-            if len(search_results) == 0 or search_results[0] in markdown:
-                continue
+        best_result = select_best_search_result(search_results)
 
-            best_result = select_best_search_result(search_results)
+        uri = fmt_uri(best_result)
 
-            uri = fmt_uri(best_result)
+        if len(markdown.strip()) == 0 or NO_TIPS_PLACEHOLDER.lower() in markdown.lower():
+            markdown = fmt_page_heading(county, state)
 
-            if len(markdown.strip()) == 0 or NO_TIPS_PLACEHOLDER.lower() in markdown.lower():
-                markdown = fmt_page_heading(county, state)
+        markdown = markdown + fmt_entry(title, uri, access_time)
 
-            markdown = markdown + fmt_entry(title, uri, access_time)
-
-            with open(state + "/" + county + ".md", "w") as county_file:
-                county_file.write(markdown)
+        with open(state + "/" + county + ".md", "w") as county_file:
+            county_file.write(markdown)
 
 
 class CountyInfo:
@@ -143,7 +138,7 @@ class CountyInfo:
         self.density = density
 
 
-def select_best_search_result(search_results):
+def get_prioritized_county_list():
     county_info_list = []
     with open('county_list.csv', newline='') as f:
         r = csv.reader(f, delimiter=',')
@@ -153,11 +148,33 @@ def select_best_search_result(search_results):
                 density = calculate_information_density(county_file.read())
                 county_info_list.append(CountyInfo(county, state, density))
 
+    # Naive quartile implementation is safe so long as we have many counties to
+    # work from.
+    county_info_list = sorted(county_info_list, key=lambda x: x.density)
+    quartile_size = len(county_info_list) / 4
+    q1 = county_info_list[quartile_size*0:quartile_size*1]
+    q2 = county_info_list[quartile_size*1:quartile_size*2]
+    q3 = county_info_list[quartile_size*2:quartile_size*3]
+    q4 = county_info_list[quartile_size*3:]
+
+    random.shuffle(q1)
+    random.shuffle(q2)
+    random.shuffle(q3)
+    random.shuffle(q4)
+
+    return [(x.county, x.state) for x in q1+q2+q3+q4]
+
 
 def calculate_information_density(text):
     """estimate information density based on the count of non-whitespace
     characters in the text"""
     return len(["" if c in ['\n', '\r', '\t', ' '] else c for c in text])
+
+
+def select_best_search_result(search_results):
+    # currently implemented to just return the top result, this could be
+    # extended in any number of ways.
+    return search_results[0]
 
 
 def replace_underscores(s):

--- a/scrape.py
+++ b/scrape.py
@@ -117,7 +117,9 @@ def main():
             if len(search_results) == 0 or search_results[0] in markdown:
                 continue
 
-            uri = select_best_search_result(search_results)
+            best_result = select_best_search_result(search_results)
+            
+            uri = fmt_uri(best_result)
 
             if len(markdown.strip()) == 0 or NO_TIPS_PLACEHOLDER.lower() in markdown.lower():
                 markdown = fmt_page_heading(county, state)
@@ -149,6 +151,10 @@ def fmt_access_time():
 
 def fmt_page_heading(county, state):
     return "## Covid tips for {}, {}\n---".format(county, state)
+
+
+def fmt_uri(uri):
+    return "**Link: [uri](uri)**"
 
 
 def fmt_entry(title, uri, access_time):

--- a/scrape.py
+++ b/scrape.py
@@ -141,11 +141,11 @@ def replace_underscores(s):
 
 
 def fmt_title(engine_name, subject):
-    return "### '{}' Search for **'{}'**".format(engine_name, subject)
+    return "\n\n<br>\n\n---\n### '{}' Search for **'{}'**".format(engine_name, subject)
 
 
 def fmt_access_time():
-    return "*(Retrieved on {})*".format(
+    return "*Retrieved {}*".format(
         datetime.utcnow().strftime("%A, %B %-d, %Y at %-I:%M%p (UTC)"))
 
 
@@ -158,7 +158,7 @@ def fmt_uri(uri):
 
 
 def fmt_entry(title, uri, access_time):
-    return "---{}\n\n{}\n\n{}".format(title, access_time, uri)
+    return "{}\n\n{}\n\n{}".format(title, access_time, uri)
 
 
 def prush(*args):

--- a/scrape.py
+++ b/scrape.py
@@ -112,8 +112,13 @@ def main():
         access_time = fmt_access_time()
 
         markdown = ""
-        with open(state + "/" + county + ".md", "r") as county_file:
-            markdown = county_file.read()
+        file_name = state + "/" + county + ".md"
+        try:
+            with open(file_name, "r") as county_file:
+                markdown = county_file.read()
+        except:
+            print("unable to open {}", file_name)
+            continue
 
         if len(search_results) == 0 or search_results[0] in markdown:
             continue
@@ -140,13 +145,18 @@ class CountyInfo:
 
 def get_prioritized_county_list():
     county_info_list = []
-    with open('county_list.csv', newline='') as f:
+    with open('county_list.csv', newline='', encoding='iso8859_15') as f:
         r = csv.reader(f, delimiter=',')
         for row in r:
+            print(row)
             county, state = row[0], row[1]
-            with open(state + "/" + county + ".md", "r") as county_file:
-                density = calculate_information_density(county_file.read())
-                county_info_list.append(CountyInfo(county, state, density))
+            file_name = state + "/" + county + ".md"
+            try:
+                with open(file_name, "r") as county_file:
+                    density = calculate_information_density(county_file.read())
+                    county_info_list.append(CountyInfo(county, state, density))
+            except:
+                print("unable to open '{}'".format(file_name))
 
     # Naive quartile implementation is safe so long as we have many counties to
     # work from.

--- a/scrape.py
+++ b/scrape.py
@@ -70,9 +70,14 @@ def main():
         engine_times = dict()
         r = csv.reader(f, delimiter=',')
         for row in r:
-            county, state = replace_underscores(
-                row[0]), replace_underscores(row[1])
-            prush("{}, {}...".format(county, state))
+            # use these instances to access files (may contain underscores)
+            county, state = row[0], row[1]
+
+            # use these values for search queries and formatted output
+            county_clean, state_clean = replace_underscores(
+                county), replace_underscores(state)
+
+            prush("{}, {}...".format(county_clean, state_clean))
 
             time_since_last_use = 0
             engine_name = ""
@@ -90,13 +95,14 @@ def main():
                     break
 
             engine.set_headers({'User-Agent': get_random_user_agent()})
-            subject = PREFERRED_SEARCH_TEMPLATE.format(county, state)
+            subject = PREFERRED_SEARCH_TEMPLATE.format(
+                county_clean, state_clean)
             search_results = engine.search(subject, pages=SEARCH_PAGES).links()
             engine_times[engine_name] = datetime.now()
 
             if len(search_results) == 0:
                 subject = ALTERNATE_SEARCH_TEMPLATE.format(
-                    county, state)
+                    county_clean, state_clean)
 
                 # Random-uniform wait period between successive calls to same
                 # engine adds some delay and jitter to the calls, making it


### PR DESCRIPTION
Hi there. I decided to implement a second set of enhancements to the scraper.

- This PR primarily includes code changes to the scraper. 
- I will submit another PR in a while with a new slug of markdown updates from the new scraper.

## Bug Fixes
 - **Underscores now handled properly.** Counties and states that included underscores in their names in the county csv were being sent to the search engine with underscores in place, which degraded search quality.
 - **Properly handling county_list.csv's encoding.** Oddly, it appears to be iso8859_15.
 - **Ignore missing markdown files.** If a county doesn't have a markdown file for some reason, the scraper just ignores the county and moves on. It remains the `make_the_files.py` script's responsibility to generate files.

## Enhancements
**Implemented County Prioritization**
In the previous version, counties were scraped in the order that they appear in the county csv.
In that arrangement, the only way to ensure all counties get scraped was to run the scraper to completion. On the next run it would just start at the top and re-scrape the same counties over and over again. This led to counties in Alabama and Alaska receiving a lot of attention, while counties in Wisconsin and Wyoming received none.

The new prioritization scheme achieves the following:
- Generally prioritize counties with less research ahead of counties with more research
- Within the above priority, shuffle the counties on each run, so that if the scraper doesn't finish a full scrape in a single session, it won't start with the same counties a second time.

This is accomplished in the following steps:
1. For each county, find its markdown file, and estimate the information density in the file.
2. Divide the counties into 4 quartiles, with the lowest information density counties being in the 1st quartile.
3. Shuffle the order of counties within each quartile
4. Merge the quartiles, this is the prioritized county order